### PR TITLE
fixed brittle raw read of asdf file and conversion to string

### DIFF
--- a/Anatomy_of_an_ASDF_file.ipynb
+++ b/Anatomy_of_an_ASDF_file.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,9 +49,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#ASDF 1.0.0\n",
+      "#ASDF_STANDARD 1.5.0\n",
+      "%YAML 1.1\n",
+      "%TAG ! tag:stsci.edu:asdf/\n",
+      "--- !core/asdf-1.1.0\n",
+      "asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute,\n",
+      "homepage: 'http://github.com/spacetelescope/asdf',\n",
+      "  name: asdf, version: 2.7.1}\n",
+      "history:\n",
+      " extensions:\n",
+      " - !core/extension_metadata-1.0.0\n",
+      "    extension_class: asdf.extension.BuiltinExtension\n",
+      "    software: {name: asdf, version: 2.0.0}\n",
+      "target:\n",
+      "  name: 47 Tuc\n",
+      "  ra: 00h 21m 52.393s\n",
+      "  dec: -72d 21m 30.63s\n",
+      "  frame:\n",
+      "    name: FK4\n",
+      "    epoch: 1950\n",
+      "    equinox: 1950\n",
+      "proposer:\n",
+      "  name: Marvin\n",
+      "  institution: Mars Institute of Astronomy\n",
+      "co-Is:\n",
+      "- Bugs Bunny\n",
+      "- Elmer Fudd\n",
+      "- Tasmanian Devil\n",
+      "...\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "with open(filepath) as asdffile: print(asdffile.read())"
    ]
@@ -67,9 +104,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root (AsdfObject)\n",
+      "├─asdf_library (Software)\n",
+      "│ ├─author (str): Space Telescope Science Institute\n",
+      "│ ├─homepage (str): http://github.com/spacetelescope/asdf\n",
+      "│ ├─name (str): asdf\n",
+      "│ └─version (str): 2.7.1\n",
+      "├─history (dict)\n",
+      "│ └─extensions (list)\n",
+      "│   └─[0] (ExtensionMetadata) ...\n",
+      "├─target (dict)\n",
+      "│ ├─name (str): 47 Tuc\n",
+      "│ ├─ra (str): 00h 21m 52.393s\n",
+      "│ ├─dec (str): -72d 21m 30.63s\n",
+      "│ └─frame (dict)\n",
+      "│   ├─name (str): FK4\n",
+      "│   └─2 not shown\n",
+      "├─proposer (dict)\n",
+      "│ ├─name (str): Marvin\n",
+      "│ └─institution (str): Mars Institute of Astronomy\n",
+      "└─co-Is (list)\n",
+      "  ├─[0] (str): Bugs Bunny\n",
+      "  ├─[1] (str): Elmer Fudd\n",
+      "  └─[2] (str): Tasmanian Devil\n",
+      "Some nodes not shown.\n"
+     ]
+    }
+   ],
    "source": [
     "af = asdf.open(filepath)\n",
     "af.info()"
@@ -84,27 +152,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': '47 Tuc',\n",
+       " 'ra': '00h 21m 52.393s',\n",
+       " 'dec': '-72d 21m 30.63s',\n",
+       " 'frame': {'name': 'FK4', 'epoch': 1950, 'equinox': 1950}}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af['target']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'FK4'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af['target']['frame']['name']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Elmer Fudd'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af['co-Is'][1]"
    ]
@@ -118,9 +222,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root (AsdfObject)\n",
+      "├─asdf_library (Software)\n",
+      "│ ├─author (str): Space Telescope Science Institute\n",
+      "│ ├─homepage (str): http://github.com/spacetelescope/asdf\n",
+      "│ ├─name (str): asdf\n",
+      "│ └─version (str): 2.7.1\n",
+      "├─history (dict)\n",
+      "│ └─extensions (list)\n",
+      "│   └─[0] (ExtensionMetadata) ...\n",
+      "├─target (dict)\n",
+      "│ ├─name (str): 47 Tuc\n",
+      "│ ├─ra (str): 00h 21m 52.393s\n",
+      "│ ├─dec (str): -72d 21m 30.63s\n",
+      "│ └─frame (dict) ...\n",
+      "├─proposer (dict)\n",
+      "│ ├─name (str): Marvin\n",
+      "│ └─institution (str): Mars Institute of Astronomy\n",
+      "├─co-Is (list)\n",
+      "│ ├─[0] (str): Bugs Bunny\n",
+      "│ ├─[1] (str): Elmer Fudd\n",
+      "│ └─[2] (str): Tasmanian Devil\n",
+      "├─data1 (ndarray): shape=(10, 10), dtype=float64\n",
+      "└─data2 (ndarray): shape=(10,), dtype=float64\n",
+      "Some nodes not shown.\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "af['data1'] = np.ones((10,10))\n",
@@ -130,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,22 +274,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b'#ASDF 1.0.0\\n#ASDF_STANDARD 1.5.0\\n%YAML 1.1\\n%TAG ! tag:stsci.edu:asdf/\\n--- !core/asdf-1.1.0\\nasdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: \\'http://github.com/asdf-format/asdf\\',\\n  name: asdf, version: 2.8.0}\\nhistory:\\n  extensions:\\n  - !core/extension_metadata-1.0.0\\n    extension_class: asdf.extension.BuiltinExtension\\n    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\\nco-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\\ndata1: !core/ndarray-1.0.0\\n  source: 0\\n  datatype: float64\\n  byteorder: little\\n  shape: [10, 10]\\ndata2: !core/ndarray-1.0.0\\n  source: 1\\n  datatype: float64\\n  byteorder: little\\n  shape: [10]\\nproposer: {institution: Mars Institute of Astronomy, name: Marvin}\\ntarget:\\n  dec: -72d 21m 30.63s\\n  frame: {epoch: 1950, equinox: 1950, name: FK4}\\n  name: 47 Tuc\\n  ra: 00h 21m 52.393s\\n...\\n\\xd3BLK\\x000\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x03 \\x00\\x00\\x00\\x00\\x00\\x00\\x03 \\x00\\x00\\x00\\x00\\x00\\x00\\x03 #v\\xa27Yw\\x07\\r\\xc3\"\\t\\xa8\\xa7\\xbd*\\x99\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\xd3BLK\\x000\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00P\\x00\\x00\\x00\\x00\\x00\\x00\\x00P\\x00\\x00\\x00\\x00\\x00\\x00\\x00P\\xbb\\xf7\\xc6\\x07yb\\xa7\\xc2\\x81\\x14\\xdb\\xd1\\x0b\\xe9G\\xcd\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00#ASDF BLOCK INDEX\\n%YAML 1.1\\n---\\n- 836\\n- 1690\\n...\\n'\n"
+     ]
+    }
+   ],
    "source": [
     "# Open as an ordinary file first\n",
-    "with open('tut_with_data.asdf','rb') as taf2: print(taf2.read())"
+    "with open('tut_with_data.asdf','rb') as taf2:\n",
+    "    print(taf2.read())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#ASDF 1.0.0\n",
+      "#ASDF_STANDARD 1.5.0\n",
+      "%YAML 1.1\n",
+      "%TAG ! tag:stsci.edu:asdf/\n",
+      "--- !core/asdf-1.1.0\n",
+      "asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',\n",
+      "  name: asdf, version: 2.8.0}\n",
+      "history:\n",
+      "  extensions:\n",
+      "  - !core/extension_metadata-1.0.0\n",
+      "    extension_class: asdf.extension.BuiltinExtension\n",
+      "    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\n",
+      "co-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\n",
+      "data1: !core/ndarray-1.0.0\n",
+      "  source: 0\n",
+      "  datatype: float64\n",
+      "  byteorder: little\n",
+      "  shape: [10, 10]\n",
+      "data2: !core/ndarray-1.0.0\n",
+      "  source: 1\n",
+      "  datatype: float64\n",
+      "  byteorder: little\n",
+      "  shape: [10]\n",
+      "proposer: {institution: Mars Institute of Astronomy, name: Marvin}\n",
+      "target:\n",
+      "  dec: -72d 21m 30.63s\n",
+      "  frame: {epoch: 1950, equinox: 1950, name: FK4}\n",
+      "  name: 47 Tuc\n",
+      "  ra: 00h 21m 52.393s\n",
+      "...\n"
+     ]
+    }
+   ],
    "source": [
     "# Print as string, but requires conversion of text part\n",
-    "with open('tut_with_data.asdf','rb') as taf2: print(taf2.read()[:852].decode(\"utf-8\"))"
+    "with open('tut_with_data.asdf','rb') as taf2:\n",
+    "    fbytes = taf2.read()\n",
+    "    end = fbytes.find(b'...')\n",
+    "    print(fbytes[: end + 3].decode(\"utf-8\"))"
    ]
   },
   {
@@ -176,9 +360,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root (AsdfObject)\n",
+      "├─asdf_library (Software)\n",
+      "│ ├─author (str): The ASDF Developers\n",
+      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
+      "│ ├─name (str): asdf\n",
+      "│ └─version (str): 2.8.0\n",
+      "├─history (dict)\n",
+      "│ └─extensions (list)\n",
+      "│   └─[0] (ExtensionMetadata) ...\n",
+      "├─co-Is (list)\n",
+      "│ ├─[0] (str): Bugs Bunny\n",
+      "│ ├─[1] (str): Elmer Fudd\n",
+      "│ └─[2] (str): Tasmanian Devil\n",
+      "├─data1 (NDArrayType): shape=(10, 10), dtype=float64\n",
+      "├─data2 (NDArrayType): shape=(10,), dtype=float64\n",
+      "├─proposer (dict)\n",
+      "│ ├─institution (str): Mars Institute of Astronomy\n",
+      "│ └─name (str): Marvin\n",
+      "└─target (dict)\n",
+      "  ├─dec (str): -72d 21m 30.63s\n",
+      "  ├─frame (dict) ...\n",
+      "  ├─name (str): 47 Tuc\n",
+      "  └─ra (str): 00h 21m 52.393s\n",
+      "Some nodes not shown.\n"
+     ]
+    }
+   ],
    "source": [
     "# Now open as an asdf file\n",
     "af2 = asdf.open('tut_with_data.asdf')\n",
@@ -187,18 +402,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10, 10)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af2['data1'].shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af2['data2']"
    ]
@@ -214,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,25 +461,77 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root (AsdfObject)\n",
+      "├─asdf_library (Software)\n",
+      "│ ├─author (str): The ASDF Developers\n",
+      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
+      "│ ├─name (str): asdf\n",
+      "│ └─version (str): 2.8.0\n",
+      "├─history (dict)\n",
+      "│ └─extensions (list)\n",
+      "│   └─[0] (ExtensionMetadata)\n",
+      "│     ├─extension_class (str): asdf.extension.BuiltinExtension\n",
+      "│     └─software (Software)\n",
+      "│       ├─name (str): asdf\n",
+      "│       └─version (str): 2.8.0\n",
+      "├─co-Is (list)\n",
+      "│ ├─[0] (str): Bugs Bunny\n",
+      "│ ├─[1] (str): Elmer Fudd\n",
+      "│ └─[2] (str): Tasmanian Devil\n",
+      "├─data1 (NDArrayType): shape=(10, 10), dtype=float64\n",
+      "├─data2 (NDArrayType): shape=(10,), dtype=float64\n",
+      "├─proposer (dict)\n",
+      "│ ├─institution (str): Mars Institute of Astronomy\n",
+      "│ └─name (str): Marvin\n",
+      "├─target (dict)\n",
+      "│ ├─dec (str): -72d 21m 30.63s\n",
+      "│ ├─frame (dict)\n",
+      "│ │ ├─epoch (int): 1950\n",
+      "│ │ ├─equinox (int): 1950\n",
+      "│ │ └─name (str): FK4\n",
+      "│ ├─name (str): 47 Tuc\n",
+      "│ └─ra (str): 00h 21m 52.393s\n",
+      "└─misc (dict)\n",
+      "  └─my_very_lucky_numbers (list)\n",
+      "    ├─[0] (int): 3\n",
+      "    └─[1] (int): 7\n"
+     ]
+    }
+   ],
    "source": [
     "af2.info(max_rows=None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'my_very_lucky_numbers': [3, 7]}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af2['misc']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,16 +541,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'my_very_lucky_numbers': [3, 7, 13, 27]}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af2['misc']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,27 +610,111 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root (AsdfObject)\n",
+      "├─asdf_library (Software)\n",
+      "│ ├─author (str): The ASDF Developers\n",
+      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
+      "│ ├─name (str): asdf\n",
+      "│ └─version (str): 2.8.0\n",
+      "├─history (dict)\n",
+      "│ └─extensions (list)\n",
+      "│   └─[0] (ExtensionMetadata) ...\n",
+      "├─co-Is (list)\n",
+      "│ ├─[0] (str): Bugs Bunny\n",
+      "│ ├─[1] (str): Elmer Fudd\n",
+      "│ └─[2] (str): Tasmanian Devil\n",
+      "├─data1 (NDArrayType): shape=(10, 10), dtype=float64\n",
+      "├─data2 (NDArrayType): shape=(10,), dtype=float64\n",
+      "├─proposer (dict)\n",
+      "│ ├─institution (str): Mars Institute of Astronomy\n",
+      "│ └─name (str): Marvin\n",
+      "└─misc (dict)\n",
+      "  ├─my_very_lucky_numbers (list) ...\n",
+      "  ├─ingredients_for_cornbread (dict) ...\n",
+      "  └─speech (str): \n",
+      "Four score and seven years ago our fathers brought forth on this continen (truncated)\n",
+      "Some nodes not shown.\n"
+     ]
+    }
+   ],
    "source": [
     "af2.info()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'my_very_lucky_numbers': [3, 7, 13, 27],\n",
+       " 'ingredients_for_cornbread': {'flour': <Quantity 0.25 l>,\n",
+       "  'yellow cornmeal': <Quantity 0.25 l>,\n",
+       "  'white sugar': <Quantity 0.16666667 l>,\n",
+       "  'salt': <Quantity 5. ml>,\n",
+       "  'egg': 1,\n",
+       "  'milk': <Quantity 0.25 l>,\n",
+       "  'vegetable oil': <Quantity 0.25 l>},\n",
+       " 'speech': '\\nFour score and seven years ago our fathers brought forth on this continent,\\na new nation, conceived in Liberty,\\nand dedicated to the proposition that all men are created equal.\\n\\nNow we are engaged in a great civil war,\\ntesting whether that nation, or any nation so conceived and so dedicated,\\ncan long endure. We are met on a great battle-field of that war.\\nWe have come to dedicate a portion of that field, as a final resting\\nplace for those who here gave their lives that that nation might live.\\nIt is altogether fitting and proper that we should do this.\\n\\nBut, in a larger sense, we can not dedicate -- we can not consecrate\\n-- we can not hallow -- this ground. The brave men, living and dead,\\nwho struggled here, have consecrated it, far above our poor power to\\nadd or detract. The world will little note, nor long remember what we\\nsay here, but it can never forget what they did here.\\nIt is for us the living, rather, to be dedicated here to the\\nunfinished work which they who fought here have thus far so nobly advanced.\\nIt is rather for us to be here dedicated to the great task remaining before us\\n-- that from these honored dead we take increased devotion to that cause for\\nwhich they gave the last full measure of devotion -- \\nthat we here highly resolve that these dead shall not have died in vain --\\nthat this nation, under God, shall have a new birth of freedom --\\nand that government of the people, by the people, for the people,\\nshall not perish from the earth.\\n'}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af2['misc']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Four score and seven years ago our fathers brought forth on this continent,\n",
+      "a new nation, conceived in Liberty,\n",
+      "and dedicated to the proposition that all men are created equal.\n",
+      "\n",
+      "Now we are engaged in a great civil war,\n",
+      "testing whether that nation, or any nation so conceived and so dedicated,\n",
+      "can long endure. We are met on a great battle-field of that war.\n",
+      "We have come to dedicate a portion of that field, as a final resting\n",
+      "place for those who here gave their lives that that nation might live.\n",
+      "It is altogether fitting and proper that we should do this.\n",
+      "\n",
+      "But, in a larger sense, we can not dedicate -- we can not consecrate\n",
+      "-- we can not hallow -- this ground. The brave men, living and dead,\n",
+      "who struggled here, have consecrated it, far above our poor power to\n",
+      "add or detract. The world will little note, nor long remember what we\n",
+      "say here, but it can never forget what they did here.\n",
+      "It is for us the living, rather, to be dedicated here to the\n",
+      "unfinished work which they who fought here have thus far so nobly advanced.\n",
+      "It is rather for us to be here dedicated to the great task remaining before us\n",
+      "-- that from these honored dead we take increased devotion to that cause for\n",
+      "which they gave the last full measure of devotion -- \n",
+      "that we here highly resolve that these dead shall not have died in vain --\n",
+      "that this nation, under God, shall have a new birth of freedom --\n",
+      "and that government of the people, by the people, for the people,\n",
+      "shall not perish from the earth.\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(af2['misc']['speech'])"
    ]
@@ -346,9 +730,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([   1, -100,    2,    3,    5,    8,   13,   21])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Illustrate with a small array\n",
     "refdata = np.array([1, 1, 2, 3, 5, 8, 13, 21])\n",
@@ -362,9 +757,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([   1, -100,    2,    3,    5,    8,   13,   21])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Save to a new file\n",
     "af2.write_to('tut_with_data2.asdf')\n",
@@ -375,18 +781,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([   1, -100,    2,    3,    5,    8,   13,   21])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af3['misc']['ref2']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 333, -100,    2,    3,    5,    8,   13,   21])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "af3['misc']['ref2'][0] = 333\n",
     "af3['ref1']"
@@ -401,9 +829,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#ASDF 1.0.0\n",
+      "#ASDF_STANDARD 1.5.0\n",
+      "%YAML 1.1\n",
+      "%TAG ! tag:stsci.edu:asdf/\n",
+      "--- !core/asdf-1.1.0\n",
+      "asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',\n",
+      "  name: asdf, version: 2.8.0}\n",
+      "history:\n",
+      "  extensions:\n",
+      "  - !core/extension_metadata-1.0.0\n",
+      "    extension_class: asdf.extension.BuiltinExtension\n",
+      "    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\n",
+      "  - !core/extension_metadata-1.0.0\n",
+      "    extension_class: astropy.io.misc.asdf.extension.AstropyAsdfExtension\n",
+      "    software: !core/software-1.0.0 {name: astropy, version: 4.3.dev644+gc30154b8f.d20210507}\n",
+      "co-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\n",
+      "data1: !core/ndarray-1.0.0\n",
+      "  source: 0\n",
+      "  datatype: float64\n",
+      "  byteorder: little\n",
+      "  shape: [10, 10]\n",
+      "data2: !core/ndarray-1.0.0\n",
+      "  source: 1\n",
+      "  datatype: float64\n",
+      "  byteorder: little\n",
+      "  shape: [10]\n",
+      "misc:\n",
+      "  ingredients_for_cornbread:\n",
+      "    egg: 1\n",
+      "    flour: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "    milk: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "    salt: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 cm3, value: 5.0}\n",
+      "    vegetable oil: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "    white sugar: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.16666666666666666}\n",
+      "    yellow cornmeal: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "  my_very_lucky_numbers: [3, 7, 13, 27]\n",
+      "  ref2: &id001 !core/ndarray-1.0.0\n",
+      "    source: 2\n",
+      "    datatype: int64\n",
+      "    byteorder: little\n",
+      "    shape: [8]\n",
+      "  speech: \"\\nFour score and seven years ago our fathers brought forth on this continent,\\na\n",
+      "    new nation, conceived in Liberty,\\nand dedicated to the proposition that all men\n",
+      "    are created equal.\\n\\nNow we are engaged in a great civil war,\\ntesting whether\n",
+      "    that nation, or any nation so conceived and so dedicated,\\ncan long endure. We\n",
+      "    are met on a great battle-field of that war.\\nWe have come to dedicate a portion\n",
+      "    of that field, as a final resting\\nplace for those who here gave their lives that\n",
+      "    that nation might live.\\nIt is altogether fitting and proper that we should do\n",
+      "    this.\\n\\nBut, in a larger sense, we can not dedicate -- we can not consecrate\\n--\n",
+      "    we can not hallow -- this ground. The brave men, living and dead,\\nwho struggled\n",
+      "    here, have consecrated it, far above our poor power to\\nadd or detract. The world\n",
+      "    will little note, nor long remember what we\\nsay here, but it can never forget\n",
+      "    what they did here.\\nIt is for us the living, rather, to be dedicated here to\n",
+      "    the\\nunfinished work which they who fought here have thus far so nobly advanced.\\nIt\n",
+      "    is rather for us to be here dedicated to the great task remaining before us\\n--\n",
+      "    that from these honored dead we take increased devotion to that cause for\\nwhich\n",
+      "    they gave the last full measure of devotion -- \\nthat we here highly resolve that\n",
+      "    these dead shall not have died in vain --\\nthat this nation, under God, shall\n",
+      "    have a new birth of freedom --\\nand that government of the people, by the people,\n",
+      "    for the people,\\nshall not perish from the earth.\\n\"\n",
+      "proposer: {institution: Mars Institute of Astronomy, name: Marvin}\n",
+      "ref1: *\n"
+     ]
+    }
+   ],
    "source": [
     "# Let's look at the corresponding raw contents of the last file'\n",
     "with open('tut_with_data2.asdf','rb') as taf2: print(taf2.read()[:3204].decode(\"utf-8\"))"
@@ -436,7 +933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,9 +942,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#ASDF 1.0.0\n",
+      "#ASDF_STANDARD 1.5.0\n",
+      "%YAML 1.1\n",
+      "%TAG ! tag:stsci.edu:asdf/\n",
+      "--- !core/asdf-1.1.0\n",
+      "asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',\n",
+      "  name: asdf, version: 2.8.0}\n",
+      "history:\n",
+      "  extensions:\n",
+      "  - !core/extension_metadata-1.0.0\n",
+      "    extension_class: asdf.extension.BuiltinExtension\n",
+      "    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\n",
+      "  - !core/extension_metadata-1.0.0\n",
+      "    extension_class: astropy.io.misc.asdf.extension.AstropyAsdfExtension\n",
+      "    software: !core/software-1.0.0 {name: astropy, version: 4.3.dev644+gc30154b8f.d20210507}\n",
+      "co-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\n",
+      "data1: !core/ndarray-1.0.0\n",
+      "  data:\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
+      "  datatype: float64\n",
+      "  shape: [10, 10]\n",
+      "data2: !core/ndarray-1.0.0\n",
+      "  data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n",
+      "  datatype: float64\n",
+      "  shape: [10]\n",
+      "misc:\n",
+      "  ingredients_for_cornbread:\n",
+      "    egg: 1\n",
+      "    flour: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "    milk: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "    salt: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 cm3, value: 5.0}\n",
+      "    vegetable oil: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "    white sugar: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.16666666666666666}\n",
+      "    yellow cornmeal: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
+      "  my_very_lucky_numbers: [3, 7, 13, 27]\n",
+      "  ref2: &id001 !core/ndarray-1.0.0\n",
+      "    data: [333, -100, 2, 3, 5, 8, 13, 21]\n",
+      "    datatype: int64\n",
+      "    shape: [8]\n",
+      "  speech: \"\\nFour score and seven years ago our fathers brought forth on this continent,\\na\n",
+      "    new nation, conceived in Liberty,\\nand dedicated to the proposition that all men\n",
+      "    are created equal.\\n\\nNow we are engaged in a great civil war,\\ntesting whether\n",
+      "    that nation, or any nation so conceived and so dedicated,\\ncan long endure. We\n",
+      "    are met on a great battle-field of that war.\\nWe have come to dedicate a portion\n",
+      "    of that field, as a final resting\\nplace for those who here gave their lives that\n",
+      "    that nation might live.\\nIt is altogether fitting and proper that we should do\n",
+      "    this.\\n\\nBut, in a larger sense, we can not dedicate -- we can not consecrate\\n--\n",
+      "    we can not hallow -- this ground. The brave men, living and dead,\\nwho struggled\n",
+      "    here, have consecrated it, far above our poor power to\\nadd or detract. The world\n",
+      "    will little note, nor long remember what we\\nsay here, but it can never forget\n",
+      "    what they did here.\\nIt is for us the living, rather, to be dedicated here to\n",
+      "    the\\nunfinished work which they who fought here have thus far so nobly advanced.\\nIt\n",
+      "    is rather for us to be here dedicated to the great task remaining before us\\n--\n",
+      "    that from these honored dead we take increased devotion to that cause for\\nwhich\n",
+      "    they gave the last full measure of devotion -- \\nthat we here highly resolve that\n",
+      "    these dead shall not have died in vain --\\nthat this nation, under God, shall\n",
+      "    have a new birth of freedom --\\nand that government of the people, by the people,\n",
+      "    for the people,\\nshall not perish from the earth.\\n\"\n",
+      "proposer: {institution: Mars Institute of Astronomy, name: Marvin}\n",
+      "ref1: *id001\n",
+      "...\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Read as text\n",
     "with open('tut_with_inline_data.asdf','rb') as tafinline: print(tafinline.read().decode(\"utf-8\"))"
@@ -474,6 +1049,13 @@
     "Delete data2 and save the under a different name. Open the saved file and verify\n",
     "it contains the new items."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/Anatomy_of_an_ASDF_file.ipynb
+++ b/Anatomy_of_an_ASDF_file.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,46 +49,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#ASDF 1.0.0\n",
-      "#ASDF_STANDARD 1.5.0\n",
-      "%YAML 1.1\n",
-      "%TAG ! tag:stsci.edu:asdf/\n",
-      "--- !core/asdf-1.1.0\n",
-      "asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute,\n",
-      "homepage: 'http://github.com/spacetelescope/asdf',\n",
-      "  name: asdf, version: 2.7.1}\n",
-      "history:\n",
-      " extensions:\n",
-      " - !core/extension_metadata-1.0.0\n",
-      "    extension_class: asdf.extension.BuiltinExtension\n",
-      "    software: {name: asdf, version: 2.0.0}\n",
-      "target:\n",
-      "  name: 47 Tuc\n",
-      "  ra: 00h 21m 52.393s\n",
-      "  dec: -72d 21m 30.63s\n",
-      "  frame:\n",
-      "    name: FK4\n",
-      "    epoch: 1950\n",
-      "    equinox: 1950\n",
-      "proposer:\n",
-      "  name: Marvin\n",
-      "  institution: Mars Institute of Astronomy\n",
-      "co-Is:\n",
-      "- Bugs Bunny\n",
-      "- Elmer Fudd\n",
-      "- Tasmanian Devil\n",
-      "...\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with open(filepath) as asdffile: print(asdffile.read())"
    ]
@@ -104,40 +67,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root (AsdfObject)\n",
-      "├─asdf_library (Software)\n",
-      "│ ├─author (str): Space Telescope Science Institute\n",
-      "│ ├─homepage (str): http://github.com/spacetelescope/asdf\n",
-      "│ ├─name (str): asdf\n",
-      "│ └─version (str): 2.7.1\n",
-      "├─history (dict)\n",
-      "│ └─extensions (list)\n",
-      "│   └─[0] (ExtensionMetadata) ...\n",
-      "├─target (dict)\n",
-      "│ ├─name (str): 47 Tuc\n",
-      "│ ├─ra (str): 00h 21m 52.393s\n",
-      "│ ├─dec (str): -72d 21m 30.63s\n",
-      "│ └─frame (dict)\n",
-      "│   ├─name (str): FK4\n",
-      "│   └─2 not shown\n",
-      "├─proposer (dict)\n",
-      "│ ├─name (str): Marvin\n",
-      "│ └─institution (str): Mars Institute of Astronomy\n",
-      "└─co-Is (list)\n",
-      "  ├─[0] (str): Bugs Bunny\n",
-      "  ├─[1] (str): Elmer Fudd\n",
-      "  └─[2] (str): Tasmanian Devil\n",
-      "Some nodes not shown.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "af = asdf.open(filepath)\n",
     "af.info()"
@@ -152,63 +84,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'name': '47 Tuc',\n",
-       " 'ra': '00h 21m 52.393s',\n",
-       " 'dec': '-72d 21m 30.63s',\n",
-       " 'frame': {'name': 'FK4', 'epoch': 1950, 'equinox': 1950}}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af['target']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'FK4'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af['target']['frame']['name']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Elmer Fudd'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af['co-Is'][1]"
    ]
@@ -222,40 +118,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root (AsdfObject)\n",
-      "├─asdf_library (Software)\n",
-      "│ ├─author (str): Space Telescope Science Institute\n",
-      "│ ├─homepage (str): http://github.com/spacetelescope/asdf\n",
-      "│ ├─name (str): asdf\n",
-      "│ └─version (str): 2.7.1\n",
-      "├─history (dict)\n",
-      "│ └─extensions (list)\n",
-      "│   └─[0] (ExtensionMetadata) ...\n",
-      "├─target (dict)\n",
-      "│ ├─name (str): 47 Tuc\n",
-      "│ ├─ra (str): 00h 21m 52.393s\n",
-      "│ ├─dec (str): -72d 21m 30.63s\n",
-      "│ └─frame (dict) ...\n",
-      "├─proposer (dict)\n",
-      "│ ├─name (str): Marvin\n",
-      "│ └─institution (str): Mars Institute of Astronomy\n",
-      "├─co-Is (list)\n",
-      "│ ├─[0] (str): Bugs Bunny\n",
-      "│ ├─[1] (str): Elmer Fudd\n",
-      "│ └─[2] (str): Tasmanian Devil\n",
-      "├─data1 (ndarray): shape=(10, 10), dtype=float64\n",
-      "└─data2 (ndarray): shape=(10,), dtype=float64\n",
-      "Some nodes not shown.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "af['data1'] = np.ones((10,10))\n",
@@ -265,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,17 +139,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "b'#ASDF 1.0.0\\n#ASDF_STANDARD 1.5.0\\n%YAML 1.1\\n%TAG ! tag:stsci.edu:asdf/\\n--- !core/asdf-1.1.0\\nasdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: \\'http://github.com/asdf-format/asdf\\',\\n  name: asdf, version: 2.8.0}\\nhistory:\\n  extensions:\\n  - !core/extension_metadata-1.0.0\\n    extension_class: asdf.extension.BuiltinExtension\\n    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\\nco-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\\ndata1: !core/ndarray-1.0.0\\n  source: 0\\n  datatype: float64\\n  byteorder: little\\n  shape: [10, 10]\\ndata2: !core/ndarray-1.0.0\\n  source: 1\\n  datatype: float64\\n  byteorder: little\\n  shape: [10]\\nproposer: {institution: Mars Institute of Astronomy, name: Marvin}\\ntarget:\\n  dec: -72d 21m 30.63s\\n  frame: {epoch: 1950, equinox: 1950, name: FK4}\\n  name: 47 Tuc\\n  ra: 00h 21m 52.393s\\n...\\n\\xd3BLK\\x000\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x03 \\x00\\x00\\x00\\x00\\x00\\x00\\x03 \\x00\\x00\\x00\\x00\\x00\\x00\\x03 #v\\xa27Yw\\x07\\r\\xc3\"\\t\\xa8\\xa7\\xbd*\\x99\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\xd3BLK\\x000\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00P\\x00\\x00\\x00\\x00\\x00\\x00\\x00P\\x00\\x00\\x00\\x00\\x00\\x00\\x00P\\xbb\\xf7\\xc6\\x07yb\\xa7\\xc2\\x81\\x14\\xdb\\xd1\\x0b\\xe9G\\xcd\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00#ASDF BLOCK INDEX\\n%YAML 1.1\\n---\\n- 836\\n- 1690\\n...\\n'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Open as an ordinary file first\n",
     "with open('tut_with_data.asdf','rb') as taf2:\n",
@@ -293,46 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#ASDF 1.0.0\n",
-      "#ASDF_STANDARD 1.5.0\n",
-      "%YAML 1.1\n",
-      "%TAG ! tag:stsci.edu:asdf/\n",
-      "--- !core/asdf-1.1.0\n",
-      "asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',\n",
-      "  name: asdf, version: 2.8.0}\n",
-      "history:\n",
-      "  extensions:\n",
-      "  - !core/extension_metadata-1.0.0\n",
-      "    extension_class: asdf.extension.BuiltinExtension\n",
-      "    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\n",
-      "co-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\n",
-      "data1: !core/ndarray-1.0.0\n",
-      "  source: 0\n",
-      "  datatype: float64\n",
-      "  byteorder: little\n",
-      "  shape: [10, 10]\n",
-      "data2: !core/ndarray-1.0.0\n",
-      "  source: 1\n",
-      "  datatype: float64\n",
-      "  byteorder: little\n",
-      "  shape: [10]\n",
-      "proposer: {institution: Mars Institute of Astronomy, name: Marvin}\n",
-      "target:\n",
-      "  dec: -72d 21m 30.63s\n",
-      "  frame: {epoch: 1950, equinox: 1950, name: FK4}\n",
-      "  name: 47 Tuc\n",
-      "  ra: 00h 21m 52.393s\n",
-      "...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Print as string, but requires conversion of text part\n",
     "with open('tut_with_data.asdf','rb') as taf2:\n",
@@ -360,40 +180,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root (AsdfObject)\n",
-      "├─asdf_library (Software)\n",
-      "│ ├─author (str): The ASDF Developers\n",
-      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
-      "│ ├─name (str): asdf\n",
-      "│ └─version (str): 2.8.0\n",
-      "├─history (dict)\n",
-      "│ └─extensions (list)\n",
-      "│   └─[0] (ExtensionMetadata) ...\n",
-      "├─co-Is (list)\n",
-      "│ ├─[0] (str): Bugs Bunny\n",
-      "│ ├─[1] (str): Elmer Fudd\n",
-      "│ └─[2] (str): Tasmanian Devil\n",
-      "├─data1 (NDArrayType): shape=(10, 10), dtype=float64\n",
-      "├─data2 (NDArrayType): shape=(10,), dtype=float64\n",
-      "├─proposer (dict)\n",
-      "│ ├─institution (str): Mars Institute of Astronomy\n",
-      "│ └─name (str): Marvin\n",
-      "└─target (dict)\n",
-      "  ├─dec (str): -72d 21m 30.63s\n",
-      "  ├─frame (dict) ...\n",
-      "  ├─name (str): 47 Tuc\n",
-      "  └─ra (str): 00h 21m 52.393s\n",
-      "Some nodes not shown.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now open as an asdf file\n",
     "af2 = asdf.open('tut_with_data.asdf')\n",
@@ -402,40 +191,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(10, 10)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2['data1'].shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0.])"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2['data2']"
    ]
@@ -451,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,77 +228,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root (AsdfObject)\n",
-      "├─asdf_library (Software)\n",
-      "│ ├─author (str): The ASDF Developers\n",
-      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
-      "│ ├─name (str): asdf\n",
-      "│ └─version (str): 2.8.0\n",
-      "├─history (dict)\n",
-      "│ └─extensions (list)\n",
-      "│   └─[0] (ExtensionMetadata)\n",
-      "│     ├─extension_class (str): asdf.extension.BuiltinExtension\n",
-      "│     └─software (Software)\n",
-      "│       ├─name (str): asdf\n",
-      "│       └─version (str): 2.8.0\n",
-      "├─co-Is (list)\n",
-      "│ ├─[0] (str): Bugs Bunny\n",
-      "│ ├─[1] (str): Elmer Fudd\n",
-      "│ └─[2] (str): Tasmanian Devil\n",
-      "├─data1 (NDArrayType): shape=(10, 10), dtype=float64\n",
-      "├─data2 (NDArrayType): shape=(10,), dtype=float64\n",
-      "├─proposer (dict)\n",
-      "│ ├─institution (str): Mars Institute of Astronomy\n",
-      "│ └─name (str): Marvin\n",
-      "├─target (dict)\n",
-      "│ ├─dec (str): -72d 21m 30.63s\n",
-      "│ ├─frame (dict)\n",
-      "│ │ ├─epoch (int): 1950\n",
-      "│ │ ├─equinox (int): 1950\n",
-      "│ │ └─name (str): FK4\n",
-      "│ ├─name (str): 47 Tuc\n",
-      "│ └─ra (str): 00h 21m 52.393s\n",
-      "└─misc (dict)\n",
-      "  └─my_very_lucky_numbers (list)\n",
-      "    ├─[0] (int): 3\n",
-      "    └─[1] (int): 7\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2.info(max_rows=None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'my_very_lucky_numbers': [3, 7]}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2['misc']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,27 +256,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'my_very_lucky_numbers': [3, 7, 13, 27]}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2['misc']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,111 +314,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root (AsdfObject)\n",
-      "├─asdf_library (Software)\n",
-      "│ ├─author (str): The ASDF Developers\n",
-      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
-      "│ ├─name (str): asdf\n",
-      "│ └─version (str): 2.8.0\n",
-      "├─history (dict)\n",
-      "│ └─extensions (list)\n",
-      "│   └─[0] (ExtensionMetadata) ...\n",
-      "├─co-Is (list)\n",
-      "│ ├─[0] (str): Bugs Bunny\n",
-      "│ ├─[1] (str): Elmer Fudd\n",
-      "│ └─[2] (str): Tasmanian Devil\n",
-      "├─data1 (NDArrayType): shape=(10, 10), dtype=float64\n",
-      "├─data2 (NDArrayType): shape=(10,), dtype=float64\n",
-      "├─proposer (dict)\n",
-      "│ ├─institution (str): Mars Institute of Astronomy\n",
-      "│ └─name (str): Marvin\n",
-      "└─misc (dict)\n",
-      "  ├─my_very_lucky_numbers (list) ...\n",
-      "  ├─ingredients_for_cornbread (dict) ...\n",
-      "  └─speech (str): \n",
-      "Four score and seven years ago our fathers brought forth on this continen (truncated)\n",
-      "Some nodes not shown.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2.info()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'my_very_lucky_numbers': [3, 7, 13, 27],\n",
-       " 'ingredients_for_cornbread': {'flour': <Quantity 0.25 l>,\n",
-       "  'yellow cornmeal': <Quantity 0.25 l>,\n",
-       "  'white sugar': <Quantity 0.16666667 l>,\n",
-       "  'salt': <Quantity 5. ml>,\n",
-       "  'egg': 1,\n",
-       "  'milk': <Quantity 0.25 l>,\n",
-       "  'vegetable oil': <Quantity 0.25 l>},\n",
-       " 'speech': '\\nFour score and seven years ago our fathers brought forth on this continent,\\na new nation, conceived in Liberty,\\nand dedicated to the proposition that all men are created equal.\\n\\nNow we are engaged in a great civil war,\\ntesting whether that nation, or any nation so conceived and so dedicated,\\ncan long endure. We are met on a great battle-field of that war.\\nWe have come to dedicate a portion of that field, as a final resting\\nplace for those who here gave their lives that that nation might live.\\nIt is altogether fitting and proper that we should do this.\\n\\nBut, in a larger sense, we can not dedicate -- we can not consecrate\\n-- we can not hallow -- this ground. The brave men, living and dead,\\nwho struggled here, have consecrated it, far above our poor power to\\nadd or detract. The world will little note, nor long remember what we\\nsay here, but it can never forget what they did here.\\nIt is for us the living, rather, to be dedicated here to the\\nunfinished work which they who fought here have thus far so nobly advanced.\\nIt is rather for us to be here dedicated to the great task remaining before us\\n-- that from these honored dead we take increased devotion to that cause for\\nwhich they gave the last full measure of devotion -- \\nthat we here highly resolve that these dead shall not have died in vain --\\nthat this nation, under God, shall have a new birth of freedom --\\nand that government of the people, by the people, for the people,\\nshall not perish from the earth.\\n'}"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af2['misc']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Four score and seven years ago our fathers brought forth on this continent,\n",
-      "a new nation, conceived in Liberty,\n",
-      "and dedicated to the proposition that all men are created equal.\n",
-      "\n",
-      "Now we are engaged in a great civil war,\n",
-      "testing whether that nation, or any nation so conceived and so dedicated,\n",
-      "can long endure. We are met on a great battle-field of that war.\n",
-      "We have come to dedicate a portion of that field, as a final resting\n",
-      "place for those who here gave their lives that that nation might live.\n",
-      "It is altogether fitting and proper that we should do this.\n",
-      "\n",
-      "But, in a larger sense, we can not dedicate -- we can not consecrate\n",
-      "-- we can not hallow -- this ground. The brave men, living and dead,\n",
-      "who struggled here, have consecrated it, far above our poor power to\n",
-      "add or detract. The world will little note, nor long remember what we\n",
-      "say here, but it can never forget what they did here.\n",
-      "It is for us the living, rather, to be dedicated here to the\n",
-      "unfinished work which they who fought here have thus far so nobly advanced.\n",
-      "It is rather for us to be here dedicated to the great task remaining before us\n",
-      "-- that from these honored dead we take increased devotion to that cause for\n",
-      "which they gave the last full measure of devotion -- \n",
-      "that we here highly resolve that these dead shall not have died in vain --\n",
-      "that this nation, under God, shall have a new birth of freedom --\n",
-      "and that government of the people, by the people, for the people,\n",
-      "shall not perish from the earth.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(af2['misc']['speech'])"
    ]
@@ -730,20 +350,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([   1, -100,    2,    3,    5,    8,   13,   21])"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Illustrate with a small array\n",
     "refdata = np.array([1, 1, 2, 3, 5, 8, 13, 21])\n",
@@ -757,20 +366,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([   1, -100,    2,    3,    5,    8,   13,   21])"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Save to a new file\n",
     "af2.write_to('tut_with_data2.asdf')\n",
@@ -781,40 +379,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([   1, -100,    2,    3,    5,    8,   13,   21])"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af3['misc']['ref2']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([ 333, -100,    2,    3,    5,    8,   13,   21])"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "af3['misc']['ref2'][0] = 333\n",
     "af3['ref1']"
@@ -829,78 +405,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#ASDF 1.0.0\n",
-      "#ASDF_STANDARD 1.5.0\n",
-      "%YAML 1.1\n",
-      "%TAG ! tag:stsci.edu:asdf/\n",
-      "--- !core/asdf-1.1.0\n",
-      "asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',\n",
-      "  name: asdf, version: 2.8.0}\n",
-      "history:\n",
-      "  extensions:\n",
-      "  - !core/extension_metadata-1.0.0\n",
-      "    extension_class: asdf.extension.BuiltinExtension\n",
-      "    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\n",
-      "  - !core/extension_metadata-1.0.0\n",
-      "    extension_class: astropy.io.misc.asdf.extension.AstropyAsdfExtension\n",
-      "    software: !core/software-1.0.0 {name: astropy, version: 4.3.dev644+gc30154b8f.d20210507}\n",
-      "co-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\n",
-      "data1: !core/ndarray-1.0.0\n",
-      "  source: 0\n",
-      "  datatype: float64\n",
-      "  byteorder: little\n",
-      "  shape: [10, 10]\n",
-      "data2: !core/ndarray-1.0.0\n",
-      "  source: 1\n",
-      "  datatype: float64\n",
-      "  byteorder: little\n",
-      "  shape: [10]\n",
-      "misc:\n",
-      "  ingredients_for_cornbread:\n",
-      "    egg: 1\n",
-      "    flour: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "    milk: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "    salt: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 cm3, value: 5.0}\n",
-      "    vegetable oil: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "    white sugar: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.16666666666666666}\n",
-      "    yellow cornmeal: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "  my_very_lucky_numbers: [3, 7, 13, 27]\n",
-      "  ref2: &id001 !core/ndarray-1.0.0\n",
-      "    source: 2\n",
-      "    datatype: int64\n",
-      "    byteorder: little\n",
-      "    shape: [8]\n",
-      "  speech: \"\\nFour score and seven years ago our fathers brought forth on this continent,\\na\n",
-      "    new nation, conceived in Liberty,\\nand dedicated to the proposition that all men\n",
-      "    are created equal.\\n\\nNow we are engaged in a great civil war,\\ntesting whether\n",
-      "    that nation, or any nation so conceived and so dedicated,\\ncan long endure. We\n",
-      "    are met on a great battle-field of that war.\\nWe have come to dedicate a portion\n",
-      "    of that field, as a final resting\\nplace for those who here gave their lives that\n",
-      "    that nation might live.\\nIt is altogether fitting and proper that we should do\n",
-      "    this.\\n\\nBut, in a larger sense, we can not dedicate -- we can not consecrate\\n--\n",
-      "    we can not hallow -- this ground. The brave men, living and dead,\\nwho struggled\n",
-      "    here, have consecrated it, far above our poor power to\\nadd or detract. The world\n",
-      "    will little note, nor long remember what we\\nsay here, but it can never forget\n",
-      "    what they did here.\\nIt is for us the living, rather, to be dedicated here to\n",
-      "    the\\nunfinished work which they who fought here have thus far so nobly advanced.\\nIt\n",
-      "    is rather for us to be here dedicated to the great task remaining before us\\n--\n",
-      "    that from these honored dead we take increased devotion to that cause for\\nwhich\n",
-      "    they gave the last full measure of devotion -- \\nthat we here highly resolve that\n",
-      "    these dead shall not have died in vain --\\nthat this nation, under God, shall\n",
-      "    have a new birth of freedom --\\nand that government of the people, by the people,\n",
-      "    for the people,\\nshall not perish from the earth.\\n\"\n",
-      "proposer: {institution: Mars Institute of Astronomy, name: Marvin}\n",
-      "ref1: *\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Let's look at the corresponding raw contents of the last file'\n",
     "with open('tut_with_data2.asdf','rb') as taf2: print(taf2.read()[:3204].decode(\"utf-8\"))"
@@ -933,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,87 +449,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#ASDF 1.0.0\n",
-      "#ASDF_STANDARD 1.5.0\n",
-      "%YAML 1.1\n",
-      "%TAG ! tag:stsci.edu:asdf/\n",
-      "--- !core/asdf-1.1.0\n",
-      "asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',\n",
-      "  name: asdf, version: 2.8.0}\n",
-      "history:\n",
-      "  extensions:\n",
-      "  - !core/extension_metadata-1.0.0\n",
-      "    extension_class: asdf.extension.BuiltinExtension\n",
-      "    software: !core/software-1.0.0 {name: asdf, version: 2.8.0}\n",
-      "  - !core/extension_metadata-1.0.0\n",
-      "    extension_class: astropy.io.misc.asdf.extension.AstropyAsdfExtension\n",
-      "    software: !core/software-1.0.0 {name: astropy, version: 4.3.dev644+gc30154b8f.d20210507}\n",
-      "co-Is: [Bugs Bunny, Elmer Fudd, Tasmanian Devil]\n",
-      "data1: !core/ndarray-1.0.0\n",
-      "  data:\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  - [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]\n",
-      "  datatype: float64\n",
-      "  shape: [10, 10]\n",
-      "data2: !core/ndarray-1.0.0\n",
-      "  data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n",
-      "  datatype: float64\n",
-      "  shape: [10]\n",
-      "misc:\n",
-      "  ingredients_for_cornbread:\n",
-      "    egg: 1\n",
-      "    flour: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "    milk: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "    salt: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 cm3, value: 5.0}\n",
-      "    vegetable oil: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "    white sugar: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.16666666666666666}\n",
-      "    yellow cornmeal: !unit/quantity-1.1.0 {unit: !unit/unit-1.0.0 1000cm3, value: 0.25}\n",
-      "  my_very_lucky_numbers: [3, 7, 13, 27]\n",
-      "  ref2: &id001 !core/ndarray-1.0.0\n",
-      "    data: [333, -100, 2, 3, 5, 8, 13, 21]\n",
-      "    datatype: int64\n",
-      "    shape: [8]\n",
-      "  speech: \"\\nFour score and seven years ago our fathers brought forth on this continent,\\na\n",
-      "    new nation, conceived in Liberty,\\nand dedicated to the proposition that all men\n",
-      "    are created equal.\\n\\nNow we are engaged in a great civil war,\\ntesting whether\n",
-      "    that nation, or any nation so conceived and so dedicated,\\ncan long endure. We\n",
-      "    are met on a great battle-field of that war.\\nWe have come to dedicate a portion\n",
-      "    of that field, as a final resting\\nplace for those who here gave their lives that\n",
-      "    that nation might live.\\nIt is altogether fitting and proper that we should do\n",
-      "    this.\\n\\nBut, in a larger sense, we can not dedicate -- we can not consecrate\\n--\n",
-      "    we can not hallow -- this ground. The brave men, living and dead,\\nwho struggled\n",
-      "    here, have consecrated it, far above our poor power to\\nadd or detract. The world\n",
-      "    will little note, nor long remember what we\\nsay here, but it can never forget\n",
-      "    what they did here.\\nIt is for us the living, rather, to be dedicated here to\n",
-      "    the\\nunfinished work which they who fought here have thus far so nobly advanced.\\nIt\n",
-      "    is rather for us to be here dedicated to the great task remaining before us\\n--\n",
-      "    that from these honored dead we take increased devotion to that cause for\\nwhich\n",
-      "    they gave the last full measure of devotion -- \\nthat we here highly resolve that\n",
-      "    these dead shall not have died in vain --\\nthat this nation, under God, shall\n",
-      "    have a new birth of freedom --\\nand that government of the people, by the people,\n",
-      "    for the people,\\nshall not perish from the earth.\\n\"\n",
-      "proposer: {institution: Mars Institute of Astronomy, name: Marvin}\n",
-      "ref1: *id001\n",
-      "...\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Read as text\n",
     "with open('tut_with_inline_data.asdf','rb') as tafinline: print(tafinline.read().decode(\"utf-8\"))"


### PR DESCRIPTION
The previous version assumed the text part of the sample asdf file was fixed at a certain size, but it could and was easily broken by any slight change in the representation of asdf. This version searches the binary content for the end of yaml before converting to a string.