### PR TITLE
Update tutorials to work with current versions

### DIFF
--- a/ASDF_and_World_Coordinate_Systems.ipynb
+++ b/ASDF_and_World_Coordinate_Systems.ipynb
@@ -332,7 +332,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -346,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/Anatomy_of_an_ASDF_file.ipynb
+++ b/Anatomy_of_an_ASDF_file.ipynb
@@ -343,7 +343,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## References\n",
+    "## ASDF References\n",
     "\n",
     "This provides a way of sharing the same item among different attributes or lists in the file without duplicating the information. Within the python library this is handled automatically if you assign exactly the same object to two different attributes or list items."
    ]
@@ -489,7 +489,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -503,7 +503,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/High_Level_Introduction_to_ASDF.ipynb
+++ b/High_Level_Introduction_to_ASDF.ipynb
@@ -177,8 +177,8 @@
    "metadata": {},
    "source": [
     "- [Original ASDF Paper](https://www.sciencedirect.com/science/article/pii/S2213133715000645)\n",
-    "- [Python ASDF Library Documenation](https://asdf.readthedocs.io/en/2.7.1/)\n",
-    "- [ASDF Standard Documentation](https://asdf-standard.readthedocs.io/en/1.5.0/)\n",
+    "- [Python ASDF Library Documenation](https://asdf.readthedocs.io/en/)\n",
+    "- [ASDF Standard Documentation](https://asdf-standard.readthedocs.io/en/)\n",
     "- [asdf-users mailing list](https://groups.google.com/g/asdf-users)"
    ]
   },
@@ -192,7 +192,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -206,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/Reading_a_JWST_ASDF_file.ipynb
+++ b/Reading_a_JWST_ASDF_file.ipynb
@@ -222,7 +222,7 @@
    "outputs": [],
    "source": [
     "# To show only where array data is located\n",
-    "af.search(type='NDArrayType')"
+    "af.search(type_='NDArrayType')"
    ]
   },
   {
@@ -359,11 +359,18 @@
     "## Exercise 3\n",
     "What are the values at that pixel in the science, dq, and error arrays? Take care with the array indices."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -377,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/Your_first_ASDF_converter.ipynb
+++ b/Your_first_ASDF_converter.ipynb
@@ -314,35 +314,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile setup.cfg\n",
-    "[metadata]\n",
-    "name = mfconverter\n",
-    "description = TODO\n",
-    "long_description = TODO\n",
-    "author = TODO\n",
+    "%%writefile pyproject.toml\n",
+    "[project]\n",
+    "name = \"mfconverter\"\n",
+    "description = \"TODO\"\n",
     "version='0.1.0'\n",
-    "license = BSD-3-Clause\n",
+    "requires-python = \">=3.9\"\n",
+    "dependencies = [\n",
+    "    \"jsonschema >=3.0.2\",\n",
+    "    \"asdf >=2.8\",\n",
+    "    \"psutil >=5.7.2\",\n",
+    "    \"numpy>=1.16\",\n",
+    "]\n",
     "\n",
-    "[options]\n",
-    "zip_safe = True\n",
-    "python_requires = >=3.6\n",
-    "setup_requires =\n",
-    "    setuptools_scm\n",
-    "install_requires =\n",
-    "    jsonschema>=3.0.2\n",
-    "    asdf>=2.8\n",
-    "    psutil>=5.7.2\n",
-    "    numpy>=1.16\n",
-    "package_dir =\n",
-    "    =src\n",
-    "packages = find:\n",
+    "[build-system]\n",
+    "requires = [\"setuptools >=61\", \"setuptools_scm[toml] >=3.4\"]\n",
+    "build-backend = \"setuptools.build_meta\"\n",
     "\n",
-    "[options.entry_points]\n",
-    "asdf.extensions =\n",
-    "    mfconverter = mfconverter.extensions:get_extensions\n",
+    "[project.entry-points.\"asdf.extensions\"]\n",
+    "mfconverter = \"mfconverter.extensions:get_extensions\"\n",
     "\n",
-    "[options.packages.find]\n",
-    "where = src\n"
+    "[tool.setuptools.packages.find]\n",
+    "where = [\"src\"]"
    ]
   },
   {
@@ -388,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e3c3246",
+   "id": "9c324eae-a4f4-4b4b-a329-8774ede07b72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,26 +393,14 @@
    "id": "f6a74c35",
    "metadata": {},
    "source": [
-    "Now restart the kernel (you don't need to understand this cell)."
+    "**Now restart the kernel by going up to the menu bar, click on kernel, and select restart kernel, and confirm**\n",
+    "---------------------------------------------------------------------------------------------------------------"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5517bd8d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import display_html\n",
-    "def restartkernel() :\n",
-    "    display_html(\"<script>Jupyter.notebook.kernel.restart()</script>\",raw=True)\n",
-    "restartkernel()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6aa6fb1",
+   "id": "86715832-2626-424a-ac1d-4816fab0d878",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +466,7 @@
     "p = pid.PhotoID('man', 'invisible', image)\n",
     "af = asdf.AsdfFile()\n",
     "af.tree = {'id': p}\n",
-    "af.write_to('test1.asdf', auto_inline=200)"
+    "af.write_to('test1.asdf', all_array_storage='inline')"
    ]
   },
   {
@@ -544,7 +525,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -558,7 +539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/Your_second_ASDF_converter.ipynb
+++ b/Your_second_ASDF_converter.ipynb
@@ -321,8 +321,6 @@
     "        self.violation = violation\n",
     "        self.date = date\n",
     "        self.time = time\n",
-    "        if not isinstance(photo_id, PhotoID):\n",
-    "            raise ValueError(\"not a PhotoID instance\")\n",
     "        self.photo_id = photo_id"
    ]
   },
@@ -468,35 +466,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile setup.cfg\n",
-    "[metadata]\n",
-    "name = myconverters\n",
-    "description = TODO\n",
-    "long_description = TODO\n",
-    "author = Bullwinkle\n",
+    "%%writefile pyproject.toml\n",
+    "[project]\n",
+    "name = \"myconverters\"\n",
+    "description = \"TODO\"\n",
     "version='0.1.0'\n",
-    "license = BSD-3-Clause\n",
+    "requires-python = \">=3.9\"\n",
+    "dependencies = [\n",
+    "    \"jsonschema >=3.0.2\",\n",
+    "    \"asdf >=2.8\",\n",
+    "    \"psutil >=5.7.2\",\n",
+    "    \"numpy>=1.16\",\n",
+    "]\n",
     "\n",
-    "[options]\n",
-    "zip_safe = True\n",
-    "python_requires = >=3.6\n",
-    "setup_requires =\n",
-    "    setuptools_scm\n",
-    "install_requires =\n",
-    "    jsonschema>=3.0.2\n",
-    "    asdf>=2.8\n",
-    "    psutil>=5.7.2\n",
-    "    numpy>=1.16\n",
-    "package_dir =\n",
-    "    =src\n",
-    "packages = find:\n",
+    "[build-system]\n",
+    "requires = [\"setuptools >=61\", \"setuptools_scm[toml] >=3.4\"]\n",
+    "build-backend = \"setuptools.build_meta\"\n",
     "\n",
-    "[options.entry_points]\n",
-    "asdf.extensions =\n",
-    "    my_extension = myconverters.integration:get_extensions\n",
+    "[project.entry-points.\"asdf.extensions\"]\n",
+    "myconverters = \"myconverters.integration:get_extensions\"\n",
     "\n",
-    "[options.packages.find]\n",
-    "where = src"
+    "[tool.setuptools.packages.find]\n",
+    "where = [\"src\"]"
    ]
   },
   {
@@ -628,47 +619,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4b8c71d3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile setup.cfg\n",
-    "[metadata]\n",
-    "name = myschemas\n",
-    "description = Schemas for second converter tutorial\n",
-    "long_description = TODO\n",
-    "author = Bullwinkle\n",
-    "version='0.1.0'\n",
-    "license = BSD-3-Clause\n",
-    "\n",
-    "[options]\n",
-    "zip_safe = True\n",
-    "python_requires = >=3.6\n",
-    "setup_requires =\n",
-    "    setuptools_scm\n",
-    "install_requires =\n",
-    "    jsonschema>=3.0.2\n",
-    "    asdf>=2.8\n",
-    "    psutil>=5.7.2\n",
-    "    numpy>=1.16\n",
-    "package_dir =\n",
-    "    =src\n",
-    "packages = find:\n",
-    "\n",
-    "[options.entry_points]\n",
-    "asdf.resource_mappings =\n",
-    "    myschemas = myschemas.integration:get_resource_mappings\n",
-    "\n",
-    "[options.package_data]\n",
-    "myschemas.resources = manifests/*.yaml, schemas/*.yaml\n",
-    "\n",
-    "[options.packages.find]\n",
-    "where = src\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "2e0e88f6",
    "metadata": {},
@@ -679,6 +629,46 @@
     "\n",
     "Now create the two needed schema files. The explanation of how the schema works\n",
     "will follow the creation of the schemas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "973a0a41-9639-4a21-8465-0d76c656dc3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile pyproject.toml\n",
+    "[project]\n",
+    "name = \"myschemas\"\n",
+    "description = \"Schemas for second converter tutorial\"\n",
+    "version='0.1.0'\n",
+    "requires-python = \">=3.9\"\n",
+    "dependencies = [\n",
+    "    \"jsonschema >=3.0.2\",\n",
+    "    \"asdf >=2.8\",\n",
+    "    \"psutil >=5.7.2\",\n",
+    "    \"numpy >=1.16\",\n",
+    "]\n",
+    "\n",
+    "[build-system]\n",
+    "requires = [\"setuptools >=61\", \"setuptools_scm[toml] >=3.4\"]\n",
+    "build-backend = \"setuptools.build_meta\"\n",
+    "\n",
+    "[project.entry-points.\"asdf.resource_mappings\"]\n",
+    "myschema = \"myschemas.integration:get_resource_mappings\"\n",
+    "\n",
+    "[project.entry-points.\"asdf.extensions\"]\n",
+    "myconverter = \"myconverters.integration:get_extensions\"\n",
+    "\n",
+    "[tool.package-data]\n",
+    "\"myschema.resources\" = [\n",
+    "    \"manifests/*.yaml\",\n",
+    "    \"schemas/*.yaml\",\n",
+    "]\n",
+    "\n",
+    "[tool.setuptools.packages.find]\n",
+    "where = [\"src\"]"
    ]
   },
   {
@@ -775,6 +765,7 @@
     "in this online book: https://json-schema.org/understanding-json-schema/\n",
     "\n",
     "What follows is an annotated version of the photo ID schema \n",
+    "\n",
     "```\n",
     "%YAML 1.1\n",
     "---\n",
@@ -1034,21 +1025,8 @@
     "Testing the converters\n",
     "--------------------------\n",
     "\n",
-    "The following code can restart the converter without having\n",
-    "go through the notebook again"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "76aace1b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import display_html\n",
-    "def restartkernel() :\n",
-    "    display_html(\"<script>Jupyter.notebook.kernel.restart()</script>\",raw=True)\n",
-    "restartkernel()"
+    "**Now restart the kernel as was done in the first converter tutorial**\n",
+    "----------------------------------------------------------------------"
    ]
   },
   {
@@ -1087,7 +1065,7 @@
     "af = asdf.AsdfFile()\n",
     "#af.tree = {'id': p}\n",
     "af.tree = {'citation': tc}\n",
-    "af.write_to('test.asdf', auto_inline=200)"
+    "af.write_to('test.asdf', all_array_storage='inline')"
    ]
   },
   {
@@ -1189,7 +1167,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1203,7 +1181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed the installation within the converter tutorials to use pyproject.toml

Fixed various formatting issues.

Removed code that was supposed to restart the kernel from executing a cell, that doesn't appear to work anymore; now the user is instructed to do that through the notebook interface.

Changed the use of a keyword "type" to "type_"